### PR TITLE
fix: file is not always closed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1164,8 +1164,11 @@ def setup_image(test_client, fetch_token_admin):
     file_path = os.path.join(os.path.dirname(__file__), "images", filename)
     data = open(file_path, "rb")
     header, _, _ = fetch_token_admin
-    yield path, header, data, filename
-    clear_test_data(test_client, path, key)
+    try:
+        yield path, header, data, filename
+    finally:
+        data.close()
+        clear_test_data(test_client, path, key)
 
 
 @pytest.fixture()
@@ -1174,7 +1177,10 @@ def setup_image_alternative():
     filename = "ft-test.png"
     file_path = os.path.join(os.path.dirname(__file__), "images", filename)
     data = open(file_path, "rb")
-    return data, filename
+    try:
+        yield data, filename
+    finally:
+        data.close()
 
 
 @pytest.fixture()


### PR DESCRIPTION
Use pytest fixture teardown to deterministically close opened files.

Best fix in this file:
- In `setup_image`, keep opening before `yield`, then in teardown (after `yield`) close the file in a `finally`-safe style and run existing cleanup.
- In `setup_image_alternative`, convert it from a plain-return fixture to a yield fixture so teardown can close the file after test use.

Specific edits in `tests/conftest.py`:
- Around lines 1158–1169 (`setup_image`): add `data.close()` after the `yield` and before/with cleanup.
- Around lines 1171–1177 (`setup_image_alternative`): replace `return data, filename` with `yield data, filename` and add teardown `data.close()`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._